### PR TITLE
Fix ingress definition error

### DIFF
--- a/charts/mastodon/templates/web/ingress.yaml
+++ b/charts/mastodon/templates/web/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
 {{- if .Values.web.ingress.tls }}
   tls:
-  {{- range .Values.ingress.tls }}
+  {{- range .Values.web.ingress.tls }}
     - hosts:
       {{- range .hosts }}
         - {{ . | quote }}
@@ -40,13 +40,13 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ $fullName }}
+                name: {{ $fullName }}-web
                 port:
                   number: {{ $svcPort }}
 {{ else }}
           - path: /
             backend:
-              serviceName: {{ $fullName }}
+              serviceName: {{ $fullName }}-web
               servicePort: {{ $svcPort }}
 {{- end }}
   {{- end }}


### PR DESCRIPTION
The definition for ingress is incorrect. the `Values` block is specifies should include the `web` block. Without it, you'd have to duplicate the configuration at the top level for it to work. This PR also corrects the naming of the backend service referenced by the ingress definition. Without it, the ingress would never route traffic correctly.