### PR TITLE
[Penpot] Version bump

### DIFF
--- a/charts/penpot/Chart.yaml
+++ b/charts/penpot/Chart.yaml
@@ -3,8 +3,8 @@ maintainers:
   - name: codechem
     url: https://codechem.com
 apiVersion: v2
-appVersion: 1.16.0-beta
-version: 1.0.10
+appVersion: 1.18.1
+version: 1.0.11
 description: CodeChem Penpot Helm Chart
 home: https://github.com/codechem/helm/tree/main/charts/penpot
 icon: https://avatars.githubusercontent.com/u/30179644?s=200&v=4

--- a/charts/penpot/README.md
+++ b/charts/penpot/README.md
@@ -65,9 +65,9 @@ The command removes all the Kubernetes components associated with the chart and 
 ### Backend parameters
 
 | Name                                                        | Description                                                        | Value               |
-| ----------------------------------------------------------- | ------------------------------------------------------------------ | ------------------- |
+| ----------------------------------------------------------- | ------------------------------------------------------------------ |---------------------|
 | `backend.image.repository`                                  | The Docker repository to pull the image from.                      | `penpotapp/backend` |
-| `backend.image.tag`                                         | The image tag to use.                                              | `1.16.0-beta`       |
+| `backend.image.tag`                                         | The image tag to use.                                              | `1.18.1`            |
 | `backend.image.imagePullPolicy`                             | The image pull policy to use.                                      | `IfNotPresent`      |
 | `backend.replicaCount`                                      | The number of replicas to deploy.                                  | `1`                 |
 | `backend.service.type`                                      | The service type to create.                                        | `ClusterIP`         |
@@ -90,9 +90,9 @@ The command removes all the Kubernetes components associated with the chart and 
 ### Frontend parameters
 
 | Name                             | Description                                                | Value                |
-| -------------------------------- | ---------------------------------------------------------- | -------------------- |
+| -------------------------------- | ---------------------------------------------------------- |----------------------|
 | `frontend.image.repository`      | The Docker repository to pull the image from.              | `penpotapp/frontend` |
-| `frontend.image.tag`             | The image tag to use.                                      | `1.16.0-beta`        |
+| `frontend.image.tag`             | The image tag to use.                                      | `1.18.1`             |
 | `frontend.image.imagePullPolicy` | The image pull policy to use.                              | `IfNotPresent`       |
 | `frontend.replicaCount`          | The number of replicas to deploy.                          | `1`                  |
 | `frontend.service.type`          | The service type to create.                                | `ClusterIP`          |
@@ -111,9 +111,9 @@ The command removes all the Kubernetes components associated with the chart and 
 ### Exporter parameters
 
 | Name                                                         | Description                                                        | Value                |
-| ------------------------------------------------------------ | ------------------------------------------------------------------ | -------------------- |
+| ------------------------------------------------------------ | ------------------------------------------------------------------ |----------------------|
 | `exporter.image.repository`                                  | The Docker repository to pull the image from.                      | `penpotapp/exporter` |
-| `exporter.image.tag`                                         | The image tag to use.                                              | `1.16.0-beta`        |
+| `exporter.image.tag`                                         | The image tag to use.                                              | `1.18.1`             |
 | `exporter.image.imagePullPolicy`                             | The image pull policy to use.                                      | `IfNotPresent`       |
 | `exporter.replicaCount`                                      | The number of replicas to deploy.                                  | `1`                  |
 | `exporter.service.type`                                      | The service type to create.                                        | `ClusterIP`          |

--- a/charts/penpot/values.yaml
+++ b/charts/penpot/values.yaml
@@ -43,7 +43,7 @@ backend:
   ##
   image:
     repository: penpotapp/backend
-    tag: 1.16.0-beta
+    tag: 1.18.1
     imagePullPolicy: IfNotPresent
   ## @param backend.replicaCount The number of replicas to deploy.
   ##
@@ -112,7 +112,7 @@ frontend:
   ##
   image:
     repository: penpotapp/frontend
-    tag: 1.16.0-beta
+    tag: 1.18.1
     imagePullPolicy: IfNotPresent
   ## @param frontend.replicaCount The number of replicas to deploy.
   ##
@@ -178,7 +178,7 @@ exporter:
   ##
   image:
     repository: penpotapp/exporter
-    tag: 1.16.0-beta
+    tag: 1.18.1
     imagePullPolicy: IfNotPresent
   ## @param exporter.replicaCount The number of replicas to deploy.
   ##


### PR DESCRIPTION
Penpot has had a few releases since `1.16-beta`.
It is no longer in beta, which this PR reflects.

I have bumped the Chart version according to what I think fits.
Please not how this version bump is the same for some of the PRs I am offering, so the actual bump may have to change 😉  