### PR TITLE
[Penpot] storageclass for Postgres

### DIFF
--- a/charts/penpot/Chart.yaml
+++ b/charts/penpot/Chart.yaml
@@ -4,7 +4,7 @@ maintainers:
     url: https://codechem.com
 apiVersion: v2
 appVersion: 1.16.0-beta
-version: 1.0.10
+version: 1.0.11
 description: CodeChem Penpot Helm Chart
 home: https://github.com/codechem/helm/tree/main/charts/penpot
 icon: https://avatars.githubusercontent.com/u/30179644?s=200&v=4

--- a/charts/penpot/values.yaml
+++ b/charts/penpot/values.yaml
@@ -7,6 +7,7 @@
 ## @param global.imagePullSecrets Global Docker registry secret names as an array.
 ##
 global:
+  storageClass: {{ .Values.persistance.storageClass }}
   postgresqlEnabled: false
   redisEnabled: false
   ## E.g.


### PR DESCRIPTION
Currently, when a custom `storageclass` is set, this is only reflected on some persistent volumes.
Most notily, the postgres volume is not affected. 

Now to the caveat: should I add this field to the Readme? (given that it is sort of internal, I woud tend not to, but I woud like other peoples opinion in this change)

I have bumped the Chart version according to what I think fits.
Please not how this version bump is the same for some of the PRs I am offering, so the actual bump may have to change 😉 