### PR TITLE
[Penpot] Default `postgres` user for the database

### DIFF
--- a/charts/penpot/Chart.yaml
+++ b/charts/penpot/Chart.yaml
@@ -4,7 +4,7 @@ maintainers:
     url: https://codechem.com
 apiVersion: v2
 appVersion: 1.16.0-beta
-version: 1.0.10
+version: 1.0.11
 description: CodeChem Penpot Helm Chart
 home: https://github.com/codechem/helm/tree/main/charts/penpot
 icon: https://avatars.githubusercontent.com/u/30179644?s=200&v=4

--- a/charts/penpot/values.yaml
+++ b/charts/penpot/values.yaml
@@ -474,6 +474,7 @@ postgresql:
   auth:
     username: example
     password: secretpassword
+    enablePostgresUser: false
     database: penpot
 
 ## @section Redis configuration (Check for [more parameters here](https://artifacthub.io/packages/helm/bitnami/redis))


### PR DESCRIPTION
As currently configured, a default `postgres` admin user is created in the database.
Because this user would require a password on the current version of this chart, Postgres fails to start up.
Because this user is not required/used in any way, I would vote to disable it by default.

As with my previous PR: should I add this field to the Readme? (given that it is sort of internal, I would tend not to, but I would like other people's opinion on this change)

I have bumped the Chart version according to what I think fits.
Please not how this version bump is the same for some of the PRs I am offering, so the actual bump may have to change 😉