### PR TITLE
[Penpot] Refactored how `config.flags` works

### DIFF
--- a/charts/penpot/Chart.yaml
+++ b/charts/penpot/Chart.yaml
@@ -4,7 +4,7 @@ maintainers:
     url: https://codechem.com
 apiVersion: v2
 appVersion: 1.16.0-beta
-version: 1.0.10
+version: 1.1.0
 description: CodeChem Penpot Helm Chart
 home: https://github.com/codechem/helm/tree/main/charts/penpot
 icon: https://avatars.githubusercontent.com/u/30179644?s=200&v=4

--- a/charts/penpot/templates/backend/deployment.yaml
+++ b/charts/penpot/templates/backend/deployment.yaml
@@ -50,7 +50,7 @@ spec:
             - name: PENPOT_PUBLIC_URI
               value: {{ .Values.config.publicURI | quote }}
             - name: PENPOT_FLAGS
-              value: "$PENPOT_FLAGS {{ .Values.config.flags }}"
+              value: "{{ join " " .Values.config.flags }}"
             - name: PENPOT_SECRET_KEY
               value: {{ .Values.config.apiSecretKey | quote }}
             - name: PENPOT_DATABASE_URI

--- a/charts/penpot/values.yaml
+++ b/charts/penpot/values.yaml
@@ -273,7 +273,26 @@ config:
   ## @param config.apiSecretKey A random secret key needed for persistent user sessions. Generate with `openssl rand -hex 16` for example.
   ##
   publicURI: "http://localhost:8080"
-  flags: "enable-registration enable-login disable-demo-users disable-demo-warning"
+  flags: 
+  - enable-registration
+  - enable-login
+  - disable-demo-users
+  - disable-demo-warning
+  {{- if .Values.config.smtp.enabled -}}
+  - enable-smtp
+  {{- end -}}
+  {{- if .Values.config.providers.google.enabled -}}
+  - enable-login-with-google
+  {{- end -}}
+  {{- if .Values.config.providers.gitlab.enabled -}}
+  - enable-login-with-gitlab
+  {{- end -}}
+  {{- if .Values.config.providers.oidc.enabled -}}
+  - enable-login-with-oidc
+  {{- end -}}
+  {{- if .Values.config.providers.ldap.enabled -}}
+  - enable-login-with-ldap
+  {{- end -}}
   apiSecretKey: "b46a12cb4bedc6b9df8cb3f18c708b65"
   ## @param config.postgresql.host The PostgreSQL host to connect to.
   ## @param config.postgresql.port The PostgreSQL host port to use.


### PR DESCRIPTION
Currently, getting a `provider` or `smtp` to work is kind of difficult, as this requires more than just configuring the required fields, but also setting the correct `flags`.
Given that this does not result in an error message on the console, I think documenting this clearer would be advantageous.

I have changed the shema for `flags` from `string` to `string[]` and added configurations to this field which are dynamically enabled.

I have bumped the Chart version according to what I think fits.
Please not how this version bump is the same for some of the PRs I am offering, so the actual bump may have to change 😉